### PR TITLE
Update Go version from 1.23 to 1.24 in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.23
+          go-version: 1.24
         id: go
 
       - name: Checkout code


### PR DESCRIPTION
The `golang.org/x/crypto v0.42.0` requires Go 1.24 or higher. This pull request updates the test workflow to Go 1.24.